### PR TITLE
Fix React direct call error

### DIFF
--- a/dist/react-in-markdown.es2015.js
+++ b/dist/react-in-markdown.es2015.js
@@ -113,11 +113,10 @@ var getRegexMatches = function getRegexMatches(string, regexExpression, callback
 var getPropsObject = function getPropsObject(propsString) {
   var object = {};
   getRegexMatches(propsString, matchPropRegex, function (_ref) {
-    var _ref2 = slicedToArray(_ref, 3);
-
-    var fullMatch = _ref2[0];
-    var key = _ref2[1];
-    var value = _ref2[2];
+    var _ref2 = slicedToArray(_ref, 3),
+        fullMatch = _ref2[0],
+        key = _ref2[1],
+        value = _ref2[2];
 
     object[key] = value;
   });
@@ -125,9 +124,9 @@ var getPropsObject = function getPropsObject(propsString) {
 };
 
 var link = function link(_ref) {
-  var children = _ref.children;
-  var href = _ref.href;
-  var title = _ref.title;
+  var children = _ref.children,
+      href = _ref.href,
+      title = _ref.title;
   return React.createElement(
     'a',
     { href: href, title: title },
@@ -137,15 +136,15 @@ var link = function link(_ref) {
 };
 
 var renderCustomComponents = function renderCustomComponents(props, customComponents, customLinkComponent) {
-  var children = props.children;
-  var href = props.href;
+  var children = props.children,
+      href = props.href;
 
   var foundComponent = customComponents[children[0]];
   if (foundComponent) {
     var propsObject = getPropsObject(href);
-    return foundComponent(propsObject);
+    return React.createElement(foundComponent, propsObject);
   }
-  return customLinkComponent ? customLinkComponent(props) : link(props);
+  return customLinkComponent ? React.createElement(customLinkComponent, props) : React.createElement(link, props);
 };
 
 export { renderCustomComponents };

--- a/dist/react-in-markdown.js
+++ b/dist/react-in-markdown.js
@@ -119,11 +119,10 @@ var getRegexMatches = function getRegexMatches(string, regexExpression, callback
 var getPropsObject = function getPropsObject(propsString) {
   var object = {};
   getRegexMatches(propsString, matchPropRegex, function (_ref) {
-    var _ref2 = slicedToArray(_ref, 3);
-
-    var fullMatch = _ref2[0];
-    var key = _ref2[1];
-    var value = _ref2[2];
+    var _ref2 = slicedToArray(_ref, 3),
+        fullMatch = _ref2[0],
+        key = _ref2[1],
+        value = _ref2[2];
 
     object[key] = value;
   });
@@ -131,9 +130,9 @@ var getPropsObject = function getPropsObject(propsString) {
 };
 
 var link = function link(_ref) {
-  var children = _ref.children;
-  var href = _ref.href;
-  var title = _ref.title;
+  var children = _ref.children,
+      href = _ref.href,
+      title = _ref.title;
   return React.createElement(
     'a',
     { href: href, title: title },
@@ -143,15 +142,15 @@ var link = function link(_ref) {
 };
 
 var renderCustomComponents = function renderCustomComponents(props, customComponents, customLinkComponent) {
-  var children = props.children;
-  var href = props.href;
+  var children = props.children,
+      href = props.href;
 
   var foundComponent = customComponents[children[0]];
   if (foundComponent) {
     var propsObject = getPropsObject(href);
-    return foundComponent(propsObject);
+    return React.createElement(foundComponent, propsObject);
   }
-  return customLinkComponent ? customLinkComponent(props) : link(props);
+  return customLinkComponent ? React.createElement(customLinkComponent, props) : React.createElement(link, props);
 };
 
 exports.renderCustomComponents = renderCustomComponents;

--- a/dist/react-in-markdown.umd.js
+++ b/dist/react-in-markdown.umd.js
@@ -119,11 +119,10 @@ var getRegexMatches = function getRegexMatches(string, regexExpression, callback
 var getPropsObject = function getPropsObject(propsString) {
   var object = {};
   getRegexMatches(propsString, matchPropRegex, function (_ref) {
-    var _ref2 = slicedToArray(_ref, 3);
-
-    var fullMatch = _ref2[0];
-    var key = _ref2[1];
-    var value = _ref2[2];
+    var _ref2 = slicedToArray(_ref, 3),
+        fullMatch = _ref2[0],
+        key = _ref2[1],
+        value = _ref2[2];
 
     object[key] = value;
   });
@@ -131,9 +130,9 @@ var getPropsObject = function getPropsObject(propsString) {
 };
 
 var link = function link(_ref) {
-  var children = _ref.children;
-  var href = _ref.href;
-  var title = _ref.title;
+  var children = _ref.children,
+      href = _ref.href,
+      title = _ref.title;
   return React.createElement(
     'a',
     { href: href, title: title },
@@ -143,15 +142,15 @@ var link = function link(_ref) {
 };
 
 var renderCustomComponents = function renderCustomComponents(props, customComponents, customLinkComponent) {
-  var children = props.children;
-  var href = props.href;
+  var children = props.children,
+      href = props.href;
 
   var foundComponent = customComponents[children[0]];
   if (foundComponent) {
     var propsObject = getPropsObject(href);
-    return foundComponent(propsObject);
+    return React.createElement(foundComponent, propsObject);
   }
-  return customLinkComponent ? customLinkComponent(props) : link(props);
+  return customLinkComponent ? React.createElement(customLinkComponent, props) : React.createElement(link, props);
 };
 
 exports.renderCustomComponents = renderCustomComponents;

--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 import {getPropsObject} from './src/utils';
 import {link} from './src/components';
+import React from 'react';
 
 export const renderCustomComponents = (props, customComponents, customLinkComponent) => {
   const {children, href} = props;
   const foundComponent = customComponents[children[0]];
   if (foundComponent) {
     const propsObject = getPropsObject(href);
-    return foundComponent(propsObject);
+    return React.createElement(foundComponent, propsObject);
   }
-  return customLinkComponent ? customLinkComponent(props) : link(props);
+  return customLinkComponent ? React.createElement(customLinkComponent, props) : React.createElement(link, props);
 }


### PR DESCRIPTION
 Hi! 

Calling component as a plain function call is now deprecated: https://facebook.github.io/react/warnings/legacy-factories.html

I just replaced direct calls with React.createElement() like this: https://facebook.github.io/react/warnings/legacy-factories.html#dynamic-components-without-jsx

Thx for merge.